### PR TITLE
Fjernet CD kode som utgår

### DIFF
--- a/doc/kreftpakkeforløp/koder/STATUSKODER FOR PAKKEFORLØP.txt
+++ b/doc/kreftpakkeforløp/koder/STATUSKODER FOR PAKKEFORLØP.txt
@@ -5,7 +5,6 @@ Kreftpakke::O::Overført til et annet helseforetak / sykehus
 Kreftpakke::CK::Påvist organspesifikk kreft
 Kreftpakke::CM::Mistanke om annen kreft
 Kreftpakke::CU::Påvist metastase uten kjent utgangspunkt
-Kreftpakke::CD::Mistanke om kreftsykdom (ny utredning)
 Kreftpakke::CA::Påvist annen sykdom enn kreft
 Kreftpakke::CI::Ikke påvist sykdom
 Kreftpakke::FK::Behandling start - Kirurgisk


### PR DESCRIPTION
I følge Helsedirektoratets sider kan det se ut til at CD koden utgår. Denne ble tidligere brukt for å dokumentere at et diagnostisk forløp fikk påvist organspesifikk kreft.