### PR TITLE
Fixed #63

### DIFF
--- a/archetypes/cluster/openEHR-EHR-CLUSTER.careplan_elem_req_additional_info_dips.v1.adl
+++ b/archetypes/cluster/openEHR-EHR-CLUSTER.careplan_elem_req_additional_info_dips.v1.adl
@@ -110,7 +110,7 @@ ontology
 				>
 				["at0002"] = <
 					text = <"Specification">
-					description = <"Used to specificy the care plan element. E.g., "pain" is the problem, and "in right shoulder" is the specification.">
+					description = <"Used to specificy the care plan element. E.g., \"pain\" is the problem, and \"in right shoulder\" is the specification.">
 				>
 				["at0008"] = <
 					text = <"Order Time">


### PR DESCRIPTION
- Fixed #63 caused by missing escape characters (missing \ before ")